### PR TITLE
Use findOrFail so 404 errors can be caught

### DIFF
--- a/src/Eloquent/AbstractRepository.php
+++ b/src/Eloquent/AbstractRepository.php
@@ -69,7 +69,7 @@ abstract class AbstractRepository implements RepositoryInterface
      */
     public function find($id)
     {
-        return $this->newQuery()->find($id);
+        return $this->newQuery()->findOrFail($id);
     }
 
     /**


### PR DESCRIPTION
Just `find()` results in a 500 error. `findOrFail()` allows the user to use `resources/views/errors/404.blade.php` to automatically catch the error.
